### PR TITLE
隐藏助手中的知识库和Mcp入口

### DIFF
--- a/src/renderer/src/pages/settings/AssistantSettings/index.tsx
+++ b/src/renderer/src/pages/settings/AssistantSettings/index.tsx
@@ -67,14 +67,16 @@ const AssistantSettingPopupContainer: React.FC<Props> = ({ resolve, tab, ...prop
       key: 'messages',
       label: t('assistants.settings.preset_messages')
     },
-    showKnowledgeIcon && {
-      key: 'knowledge_base',
-      label: t('assistants.settings.knowledge_base')
-    },
-    {
-      key: 'mcp',
-      label: t('assistants.settings.mcp')
-    },
+    // 知识库选项卡
+    // showKnowledgeIcon && {
+    //   key: 'knowledge_base',
+    //   label: t('assistants.settings.knowledge_base')
+    // },
+    // Mcp服务器选项卡
+    // {
+    //   key: 'mcp',
+    //   label: t('assistants.settings.mcp')
+    // },
     {
       key: 'regular_phrases',
       label: t('assistants.settings.regular_phrases.title', 'Regular Prompts')


### PR DESCRIPTION
1、隐藏助手弹层中列表上的知识库以及Mcp服务器的入口