### PR TITLE
隐藏Mcp服务器中类型选项【标准输入/输出(stdio)】以及InstallNpxUv 组件的入口

### DIFF
--- a/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettings.tsx
@@ -73,7 +73,7 @@ const McpSettings: React.FC = () => {
   } = useLocation().state as { server: MCPServer }
   const server = useMCPServer(serverId).server as MCPServer
   const { deleteMCPServer, updateMCPServer } = useMCPServers()
-  const [serverType, setServerType] = useState<MCPServer['type']>('stdio')
+  const [serverType, setServerType] = useState<MCPServer['type']>('sse')
   const [form] = Form.useForm<MCPFormValues>()
   const [loading, setLoading] = useState(false)
   const [isFormChanged, setIsFormChanged] = useState(false)
@@ -94,7 +94,7 @@ const McpSettings: React.FC = () => {
 
   // Initialize form values whenever the server changes
   useEffect(() => {
-    const serverType: MCPServer['type'] = server.type || (server.baseUrl ? 'sse' : 'stdio')
+    const serverType: MCPServer['type'] = server.type || (server.baseUrl ? 'streamableHttp' : 'sse')
     setServerType(serverType)
 
     // Set registry UI state based on command and registryUrl
@@ -438,15 +438,11 @@ const McpSettings: React.FC = () => {
             <TextArea rows={2} placeholder={t('common.description')} />
           </Form.Item>
           {server.type !== 'inMemory' && (
-            <Form.Item
-              name="serverType"
-              label={t('settings.mcp.type')}
-              rules={[{ required: true }]}
-              initialValue="stdio">
+            <Form.Item name="serverType" label={t('settings.mcp.type')} rules={[{ required: true }]} initialValue="sse">
               <Select
                 onChange={(value) => setServerType(value)}
                 options={[
-                  { label: t('settings.mcp.stdio'), value: 'stdio' },
+                  // { label: t('settings.mcp.stdio'), value: 'stdio' },
                   { label: t('settings.mcp.sse'), value: 'sse' },
                   { label: t('settings.mcp.streamableHttp'), value: 'streamableHttp' }
                 ]}

--- a/src/renderer/src/pages/settings/MCPSettings/McpSettingsNavbar.tsx
+++ b/src/renderer/src/pages/settings/MCPSettings/McpSettingsNavbar.tsx
@@ -6,7 +6,7 @@ import { ChevronDown, Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
-import InstallNpxUv from './InstallNpxUv'
+// import InstallNpxUv from './InstallNpxUv'
 
 const mcpResources = [
   {
@@ -72,6 +72,7 @@ export const McpSettingsNavbar = () => {
     )
   }))
 
+  // 搜索Mcp、更多Mcp按钮
   return (
     <NavbarRight style={{ paddingRight: isWindows ? 150 : isLinux ? 120 : 12 }}>
       <HStack alignItems="center" gap={5}>
@@ -94,7 +95,7 @@ export const McpSettingsNavbar = () => {
             <ChevronDown size={16} />
           </Button>
         </Dropdown>
-        <InstallNpxUv mini />
+        {/* <InstallNpxUv mini /> */}
       </HStack>
     </NavbarRight>
   )


### PR DESCRIPTION
1、隐藏Mcp服务器设置页面中类型的选项【标准输入/输出(stdio)】
2、更改Mcp服务器类型下拉框中显示的默认值
3、隐藏Mcp服务器中导航栏中的InstallNpxUv 组件的入口