### PR TITLE
更改“复制上一条”的快捷键

### DIFF
--- a/src/renderer/src/store/shortcuts.ts
+++ b/src/renderer/src/store/shortcuts.ts
@@ -54,7 +54,7 @@ const initialState: ShortcutsState = {
     },
     {
       key: 'copy_last_message',
-      shortcut: [isMac ? 'Command' : 'Ctrl', 'Shift', 'C'],
+      shortcut: [isMac ? 'Command' : 'Ctrl', 'Alt', 'C'],
       editable: true,
       enabled: false,
       system: false


### PR DESCRIPTION
1、鸿蒙中“复制上一条消息”的快捷方式与鸿蒙系统中的常用语设置快捷方式冲突
2、更改“复制上一条”的快捷键为【Ctrl + Alt + C】